### PR TITLE
Use env variables for Supabase client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Environment variables
 .env

--- a/README.md
+++ b/README.md
@@ -36,6 +36,17 @@ npm i
 npm run dev
 ```
 
+## Environment Variables
+
+Create a `.env` file in the project root to configure Supabase:
+
+```
+VITE_SUPABASE_URL=<Your Supabase project URL>
+VITE_SUPABASE_ANON_KEY=<Your Supabase anon key>
+```
+
+These variables are loaded automatically by Vite. The `.env` file is ignored by Git.
+
 **Edit a file directly in GitHub**
 
 - Navigate to the desired file(s).

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,13 +2,13 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://kiwviahzlghulnajudrz.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtpd3ZpYWh6bGdodWxuYWp1ZHJ6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI2MDgzNzEsImV4cCI6MjA2ODE4NDM3MX0.aFcWlPmOkWE7x9c0tv0OWOIso_24sLX0o2UnjHJrRV0";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_ANON_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABLE_KEY, {
+export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
     storage: localStorage,
     persistSession: true,


### PR DESCRIPTION
## Summary
- load Supabase URL and anon key from `import.meta.env`
- ignore `.env` and document required env vars

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 4 errors, 7 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb71b9ff3c83228bd32f83b6399d07